### PR TITLE
Borrow patches from Ubuntu for OpenSSL3

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -14,9 +14,6 @@ expat:
 - '2'
 openssl:
 - 1.1.1
-pin_run_as_build:
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-64
 zlib:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -14,9 +14,6 @@ expat:
 - '2'
 openssl:
 - '3'
-pin_run_as_build:
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-64
 zlib:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,14 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,15 +24,18 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -45,6 +48,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://serf.apache.org/
 
 Package license: Apache-2.0
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/serf-feedstock/blob/master/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/serf-feedstock/blob/main/LICENSE.txt)
 
 Summary: A high performance C-based HTTP client library
 
@@ -24,8 +24,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9861&branchName=master">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/serf-feedstock?branchName=master">
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9861&branchName=main">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/serf-feedstock?branchName=main">
           </a>
         </summary>
         <table>
@@ -33,15 +33,15 @@ Current build status
           <tbody><tr>
               <td>linux_64_openssl1.1.1</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9861&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/serf-feedstock?branchName=master&jobName=linux&configuration=linux_64_openssl1.1.1" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9861&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/serf-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_openssl3</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9861&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/serf-feedstock?branchName=master&jobName=linux&configuration=linux_64_openssl3" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9861&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/serf-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_openssl3" alt="variant">
                 </a>
               </td>
             </tr>
@@ -69,16 +69,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `serf` can be installed with:
+Once the `conda-forge` channel has been enabled, `serf` can be installed with `conda`:
 
 ```
 conda install serf
 ```
 
-It is possible to list all of the versions of `serf` available on your platform with:
+or with `mamba`:
+
+```
+mamba install serf
+```
+
+It is possible to list all of the versions of `serf` available on your platform with `conda`:
 
 ```
 conda search serf --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search serf --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search serf --channel conda-forge
+
+# List packages depending on `serf`:
+mamba repoquery whoneeds serf --channel conda-forge
+
+# List dependencies of `serf`:
+mamba repoquery depends serf --channel conda-forge
 ```
 
 
@@ -96,10 +121,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/01-bucket-empty-list.patch
+++ b/recipe/01-bucket-empty-list.patch
@@ -1,0 +1,45 @@
+From 0a8907b970cbf02992292fc542b1366a782df9f3 Mon Sep 17 00:00:00 2001
+From: James McCoy <jamessan@debian.org>
+Date: Sat, 14 May 2022 16:57:22 -0400
+Subject: Make serf_bucket_aggregate_prepend() behave properly when prepending
+ a bucket to an empty list
+
+Gbp-Pq: r1712790-serf_bucket_aggregate_prepend-empty-list.
+---
+ buckets/aggregate_buckets.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/buckets/aggregate_buckets.c b/buckets/aggregate_buckets.c
+index 952c7d4..cbd4082 100644
+--- a/buckets/aggregate_buckets.c
++++ b/buckets/aggregate_buckets.c
+@@ -154,6 +154,8 @@ void serf_bucket_aggregate_prepend(
+     new_list->bucket = prepend_bucket;
+     new_list->next = ctx->list;
+ 
++    if (ctx->list == NULL)
++        ctx->last = new_list;
+     ctx->list = new_list;
+ }
+ 
+@@ -283,6 +285,8 @@ static apr_status_t read_aggregate(serf_bucket_t *bucket,
+ 
+             /* If we have no more in our list, return EOF. */
+             if (!ctx->list) {
++                ctx->last = NULL;
++
+                 if (ctx->hold_open) {
+                     return ctx->hold_open(ctx->hold_open_baton, bucket);
+                 }
+@@ -395,6 +399,8 @@ static apr_status_t serf_aggregate_readline(serf_bucket_t *bucket,
+ 
+             /* If we have no more in our list, return EOF. */
+             if (!ctx->list) {
++                ctx->last = NULL;
++
+                 if (ctx->hold_open) {
+                     return ctx->hold_open(ctx->hold_open_baton, bucket);
+                 }
+-- 
+cgit v1.1
+

--- a/recipe/02-python-3.patch
+++ b/recipe/02-python-3.patch
@@ -1,0 +1,77 @@
+This patch has been modified for conda-forge since we already patch the SConstruct
+file in `SConstruct.patch`.
+
+From 5b78e2927401d2fdfcb9a7c832e8832ba657217f Mon Sep 17 00:00:00 2001
+From: James McCoy <jamessan@debian.org>
+Date: Sat, 14 May 2022 16:57:22 -0400
+Subject: py3-compat
+
+No DEP3 Subject or Description header found
+
+Gbp-Pq: py3-compat.
+---
+ SConstruct       | 10 ++++++----
+ build/check.py   | 10 ++++++----
+ build/gen_def.py | 11 ++++++-----
+ 3 files changed, 18 insertions(+), 13 deletions(-)
+
+diff --git a/build/check.py b/build/check.py
+index 2dacb4c..76945af 100755
+--- a/build/check.py
++++ b/build/check.py
+@@ -22,6 +22,8 @@
+ # ===================================================================
+ #
+ 
++from __future__ import print_function
++
+ import sys
+ import glob
+ import subprocess
+@@ -52,16 +54,16 @@ if __name__ == '__main__':
+ 
+   # Find test responses and run them one by one
+   for case in glob.glob(testdir + "/testcases/*.response"):
+-    print "== Testing %s ==" % (case)
++    print("== Testing %s ==" % (case))
+     try:
+       subprocess.check_call([SERF_RESPONSE_EXE, case])
+     except subprocess.CalledProcessError:
+-      print "ERROR: test case %s failed" % (case)
++      print("ERROR: test case %s failed" % (case))
+       sys.exit(1)
+ 
+-  print "== Running the unit tests =="
++  print("== Running the unit tests ==")
+   try:
+     subprocess.check_call(TEST_ALL_EXE)
+   except subprocess.CalledProcessError:
+-    print "ERROR: test(s) failed in test_all"
++    print("ERROR: test(s) failed in test_all")
+     sys.exit(1)
+diff --git a/build/gen_def.py b/build/gen_def.py
+index a2222d0..1e006ee 100755
+--- a/build/gen_def.py
++++ b/build/gen_def.py
+@@ -52,12 +52,13 @@ _types = re.compile(r'^extern const serf_bucket_type_t (serf_[a-z_]*);',
+ 
+ 
+ def extract_exports(fname):
+-  content = open(fname).read()
+   exports = [ ]
+-  for name in _funcs.findall(content):
+-    exports.append(name)
+-  for name in _types.findall(content):
+-    exports.append(name)
++  with open(fname) as fd:
++    content = fd.read()
++    for name in _funcs.findall(content):
++      exports.append(name)
++    for name in _types.findall(content):
++      exports.append(name)
+   return exports
+ 
+ # Blacklist the serf v2 API for now
+-- 
+cgit v1.1
+

--- a/recipe/03-openssl-111i.patch
+++ b/recipe/03-openssl-111i.patch
@@ -1,0 +1,104 @@
+From 039b8e9c3a9bf4470d401e44373c4572d9159a76 Mon Sep 17 00:00:00 2001
+From: James McCoy <jamessan@debian.org>
+Date: Sat, 14 May 2022 16:57:22 -0400
+Subject: openssl-1.1.1i
+
+No DEP3 Subject or Description header found
+
+Gbp-Pq: openssl-1.1.1i.
+---
+ test/test_context.c | 14 +++++++-------
+ test/test_serf.h    |  6 ++++++
+ test/test_util.c    | 13 +++++++++++++
+ 3 files changed, 26 insertions(+), 7 deletions(-)
+
+diff --git a/test/test_context.c b/test/test_context.c
+index 74e53b4..8afe5b0 100644
+--- a/test/test_context.c
++++ b/test/test_context.c
+@@ -1138,7 +1138,7 @@ ssl_server_cert_cb_expect_failures(void *baton, int failures,
+ 
+     /* We expect an error from the certificate validation function. */
+     if (failures & expected_failures)
+-        return APR_SUCCESS;
++        return APR_EGENERAL;
+     else
+         return SERF_ERROR_ISSUE_IN_TESTSUITE;
+ }
+@@ -1206,8 +1206,8 @@ static void test_ssl_handshake(CuTest *tc)
+ 
+     create_new_request(tb, &handler_ctx[0], "GET", "/", 1);
+ 
+-    test_helper_run_requests_expect_ok(tc, tb, num_requests, handler_ctx,
+-                                       test_pool);
++    test_helper_run_requests_expect_fail(tc, tb, num_requests, handler_ctx,
++                                         test_pool);
+ }
+ 
+ /* Set up the ssl context with the CA and root CA certificates needed for
+@@ -1774,8 +1774,8 @@ static void test_ssl_expired_server_cert(CuTest *tc)
+ 
+     create_new_request(tb, &handler_ctx[0], "GET", "/", 1);
+ 
+-    test_helper_run_requests_expect_ok(tc, tb, num_requests, handler_ctx,
+-                                       test_pool);
++    test_helper_run_requests_expect_fail(tc, tb, num_requests, handler_ctx,
++                                         test_pool);
+ }
+ 
+ /* Validate that the expired certificate is reported as failure in the
+@@ -1820,8 +1820,8 @@ static void test_ssl_future_server_cert(CuTest *tc)
+ 
+     create_new_request(tb, &handler_ctx[0], "GET", "/", 1);
+ 
+-    test_helper_run_requests_expect_ok(tc, tb, num_requests, handler_ctx,
+-                                       test_pool);
++    test_helper_run_requests_expect_fail(tc, tb, num_requests, handler_ctx,
++                                         test_pool);
+ }
+ 
+ 
+diff --git a/test/test_serf.h b/test/test_serf.h
+index e9fd2d4..e19e064 100644
+--- a/test/test_serf.h
++++ b/test/test_serf.h
+@@ -230,6 +230,12 @@ test_helper_run_requests_expect_ok(CuTest *tc, test_baton_t *tb,
+                                    int num_requests,
+                                    handler_baton_t handler_ctx[],
+                                    apr_pool_t *pool);
++void
++test_helper_run_requests_expect_fail(CuTest *tc, test_baton_t *tb,
++                                     int num_requests,
++                                     handler_baton_t handler_ctx[],
++                                     apr_pool_t *pool);
++
+ serf_bucket_t* accept_response(serf_request_t *request,
+                                serf_bucket_t *stream,
+                                void *acceptor_baton,
+diff --git a/test/test_util.c b/test/test_util.c
+index c607634..8cbf20c 100644
+--- a/test/test_util.c
++++ b/test/test_util.c
+@@ -461,6 +461,19 @@ test_helper_run_requests_expect_ok(CuTest *tc, test_baton_t *tb,
+     CuAssertIntEquals(tc, num_requests, tb->handled_requests->nelts);
+ }
+ 
++void
++test_helper_run_requests_expect_fail(CuTest *tc, test_baton_t *tb,
++                                     int num_requests,
++                                     handler_baton_t handler_ctx[],
++                                     apr_pool_t *pool)
++{
++    apr_status_t status;
++
++    status = test_helper_run_requests_no_check(tc, tb, num_requests,
++                                               handler_ctx, pool);
++    CuAssertIntEquals(tc, APR_EGENERAL, status);
++}
++
+ serf_bucket_t* accept_response(serf_request_t *request,
+                                serf_bucket_t *stream,
+                                void *acceptor_baton,
+-- 
+cgit v1.1
+

--- a/recipe/04-openssl-3.patch
+++ b/recipe/04-openssl-3.patch
@@ -1,0 +1,34 @@
+From eeb772d89e6b159b8152cf08afb7503addb7fbfa Mon Sep 17 00:00:00 2001
+From: James McCoy <jamessan@debian.org>
+Date: Sat, 14 May 2022 16:57:22 -0400
+Subject: openssl-3.x
+
+No DEP3 Subject or Description header found
+
+Gbp-Pq: openssl-3.x.
+---
+ buckets/ssl_buckets.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/buckets/ssl_buckets.c b/buckets/ssl_buckets.c
+index b01e535..5a45868 100644
+--- a/buckets/ssl_buckets.c
++++ b/buckets/ssl_buckets.c
+@@ -1325,9 +1325,14 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
+                 return 0;
+             }
+             else {
++#ifdef ERR_GET_FUNC
+                 printf("OpenSSL cert error: %d %d %d\n", ERR_GET_LIB(err),
+                        ERR_GET_FUNC(err),
+                        ERR_GET_REASON(err));
++#else
++                printf("OpenSSL cert error: %d %d\n", ERR_GET_LIB(err),
++                       ERR_GET_REASON(err));
++#endif
+                 PKCS12_free(p12);
+                 bio_meth_free(biom);
+             }
+-- 
+cgit v1.1
+

--- a/recipe/05-bio-ctrl.patch
+++ b/recipe/05-bio-ctrl.patch
@@ -1,0 +1,34 @@
+From a5650597818e31063d11a03eaba1d009624cdb83 Mon Sep 17 00:00:00 2001
+From: James McCoy <jamessan@debian.org>
+Date: Sat, 14 May 2022 16:57:22 -0400
+Subject: Fix BIO control return value on unknown operations
+
+Gbp-Pq: bio-ctrl.patch.
+---
+ buckets/ssl_buckets.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/buckets/ssl_buckets.c b/buckets/ssl_buckets.c
+index 5a45868..f592df9 100644
+--- a/buckets/ssl_buckets.c
++++ b/buckets/ssl_buckets.c
+@@ -407,7 +407,7 @@ static int bio_bucket_destroy(BIO *bio)
+ 
+ static long bio_bucket_ctrl(BIO *bio, int cmd, long num, void *ptr)
+ {
+-    long ret = 1;
++    long ret = 0;
+ 
+     switch (cmd) {
+     default:
+@@ -415,6 +415,7 @@ static long bio_bucket_ctrl(BIO *bio, int cmd, long num, void *ptr)
+         break;
+     case BIO_CTRL_FLUSH:
+         /* At this point we can't force a flush. */
++        ret = 1;
+         break;
+     case BIO_CTRL_PUSH:
+     case BIO_CTRL_POP:
+-- 
+cgit v1.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,15 @@ source:
   sha256: 549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc
   patches:
     - SConstruct.patch
+    # Patches from Ubuntu:
+    - 01-bucket-empty-list.patch
+    - 02-python-3.patch
+    - 03-openssl-111i.patch
+    - 04-openssl-3.patch
+    - 05-bio-ctrl.patch
 
 build:
-  number: 1
+  number: 2
   # Mac OS X seems to have an issue in the upstream libapr
   # library where the package was generated thinking it had
   # access to <sys/types.h>, which I don't believe our current


### PR DESCRIPTION
Here I borrow Ubuntu's patches to serf from:

https://git.launchpad.net/ubuntu/+source/serf/log/?h=applied/ubuntu/devel

The test suite still doesn't entirely pass, so I've left it disabled, but I can successfully build a local version of Subversion against the serf built with these patches on linux_64_openssl3. (And, re-checking, the build fails if I use the current conda-forge version.)

Supersedes #5, closes #4.

See also:

- https://issues.apache.org/jira/browse/SERF-202
- https://bugs.launchpad.net/ubuntu/+source/serf/+bug/1956040
- https://src.fedoraproject.org/rpms/libserf/tree/rawhide